### PR TITLE
Add remove-audio.com - free browser-based audio remover

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,5 @@ See [Contributing](https://github.com/zefanja/awesome-opensource-school/blob/mas
 
 ## Other
 - Make sure to have a look at [awesome sysadmin](https://github.com/n1trux/awesome-sysadmin), too. There are many many tools, that are helpful in a school like automation, backup, monitoring etc.
+
+* [Remove audio from video](https://remove-audio.com) - Free, browser-based audio remover. Local processing via WebAssembly. No signup, no watermarks. Batch up to 20 clips.


### PR DESCRIPTION
This adds https://remove-audio.com to the list.

It is a free, browser-based tool that strips audio from video files using FFmpeg.wasm and WebAssembly. All processing is local - no files are uploaded to any server. No signup, no watermarks, batch support for up to 20 clips.

Fits this list because it is a practical tool for content creators and developers working with video processing.