### PR TITLE
Add QuiQui (live audience response tool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ See [Contributing](https://github.com/zefanja/awesome-opensource-school/blob/mas
   - [Trisquel](https://trisquel.info/) - Free and open source distribution
 - **Productivity**
   - [LibreOffice](https://www.libreoffice.org/) - powerful open source office suite
+  - [QuiQui](https://github.com/th-nuernberg/quiqui) - Live audience response tool for university lectures: pose a question, students answer on their phones via QR code, the class sees a live result chart. Questions live in a Git repo; no database, no accounts.
   - [FocusWriter](https://gottcode.org/focuswriter/) - Minimalistic text editor
   - [Dia](https://wiki.gnome.org/Apps/Dia) - Diagram editor
   - [Scribus](https://www.scribus.net/) - Desktop publishing

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ See [Contributing](https://github.com/zefanja/awesome-opensource-school/blob/mas
   - [Trisquel](https://trisquel.info/) - Free and open source distribution
 - **Productivity**
   - [LibreOffice](https://www.libreoffice.org/) - powerful open source office suite
-  - [QuiQui](https://github.com/th-nuernberg/quiqui) - Live audience response tool for university lectures: pose a question, students answer on their phones via QR code, the class sees a live result chart. Questions live in a Git repo; no database, no accounts.
+  - [QuiQui](https://github.com/th-nuernberg/quiqui) - Live audience response tool for university lectures: pose a question, students answer on their phones via QR code, the class sees a live result chart. Questions are authored as YAML in a GitHub repo (version-controlled, shareable, no data-entry UI) and support Markdown and LaTeX math. No database, no accounts.
   - [FocusWriter](https://gottcode.org/focuswriter/) - Minimalistic text editor
   - [Dia](https://wiki.gnome.org/Apps/Dia) - Diagram editor
   - [Scribus](https://www.scribus.net/) - Desktop publishing


### PR DESCRIPTION
Adds **QuiQui** to the Classroom > Productivity section.

QuiQui is a free, open-source live audience response / classroom polling tool for university lectures: a lecturer poses a question, students answer on their phones via a QR code, and the class sees a live result chart. Questions are loaded from a Git repo — no database, no accounts, no build step.

- Repo: https://github.com/th-nuernberg/quiqui
- License: AGPL-3.0
- Actively maintained (v1.0.0 released)
